### PR TITLE
Fixed stylings in document page and search results page

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -7,7 +7,6 @@
     <title>{% block title %}Streaming Opinion Search{% endblock %}</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css">
     <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
-
     <style>
         .sentiment-positive {
             color: #28a745;
@@ -57,17 +56,16 @@
             background-color: #00A8E1;
             color: white;
         }
+        .platform-hbo {
+            background-color: #5822B4;
+            color: white;
+        }
         .platform-apple {
             background-color: #000000;
             color: white;
         }
-        .platform-general{
-            background-color: #6c757d2b;
-            color: black;
-            border: #0000006e 1px solid;
-        }
-        .platform-hbomax {
-            background-color: #5822B4;
+        .platform-other {
+            background-color: #6c757d;
             color: white;
         }
         .datepicker {

--- a/templates/base.html
+++ b/templates/base.html
@@ -7,6 +7,7 @@
     <title>{% block title %}Streaming Opinion Search{% endblock %}</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css">
     <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
+
     <style>
         .sentiment-positive {
             color: #28a745;
@@ -56,16 +57,17 @@
             background-color: #00A8E1;
             color: white;
         }
-        .platform-hbo {
-            background-color: #5822B4;
-            color: white;
-        }
         .platform-apple {
             background-color: #000000;
             color: white;
         }
-        .platform-other {
-            background-color: #6c757d;
+        .platform-general{
+            background-color: #6c757d2b;
+            color: black;
+            border: #0000006e 1px solid;
+        }
+        .platform-hbomax {
+            background-color: #5822B4;
             color: white;
         }
         .datepicker {

--- a/templates/base.html
+++ b/templates/base.html
@@ -56,7 +56,7 @@
             background-color: #00A8E1;
             color: white;
         }
-        .platform-hbo {
+        .platform-hbomax {
             background-color: #5822B4;
             color: white;
         }
@@ -64,9 +64,10 @@
             background-color: #000000;
             color: white;
         }
-        .platform-other {
-            background-color: #6c757d;
-            color: white;
+        .platform-general {
+            background-color: #00000026;
+            color: black;
+            border: #000000 1px solid;
         }
         .datepicker {
             width: 130px;

--- a/templates/document.html
+++ b/templates/document.html
@@ -17,24 +17,20 @@
     <div class="card-body">
         <div class="mb-4">
             {% if doc.platform %}
-            <span class="platform-tag platform-{{ doc.platform|lower|replace('+', '')|replace(' ', '')|replace("['",'')|replace("']",'')|replace('["','')|replace('"]','') }}">
-                {{ doc.platform|join(', ') }}
+            <span class="platform-tag platform-{{ doc.platform|lower|replace('+', '')|replace(' ', '') }}">
+                {{ doc.platform }}
             </span>
             {% endif %}
 
-            <!-- {% if doc.type %}
+            {% if doc.type %}
             <span class="badge bg-dark">
                 {{ doc.type }}
             </span>
-            {% endif %} -->
+            {% endif %}
 
             {% if doc.sentiment %}
-            <span class="badge 
-            {% if 'positive' in doc.sentiment %}bg-success
-            {% elif 'negative' in doc.sentiment %}bg-danger
-            {% else %}bg-secondary
-            {% endif %}">
-                {{ doc.sentiment|replace("['",'')|replace("']",'')|replace('["','')|replace('"]','') }}
+            <span class="badge {% if doc.sentiment == 'positive' %}bg-success{% elif doc.sentiment == 'negative' %}bg-danger{% else %}bg-secondary{% endif %}">
+                {{ doc.sentiment }}
             </span>
             {% endif %}
 
@@ -44,18 +40,18 @@
             </span>
             {% endif %}
 
-            <!-- {% if doc.word_count %}
+            {% if doc.word_count %}
             <span class="badge bg-secondary">
-                Words: {{ doc.word_count[0] }}
+                Words: {{ doc.word_count }}
             </span>
-            {% endif %} -->
+            {% endif %}
         </div>
 
         <!-- Original Text -->
         <div class="mb-4">
             <h5>Original Content:</h5>
             <div class="p-3 bg-light rounded">
-                {{ doc.text.0|replace('\n', '<br>')|safe if doc.text else "No content available" }}
+                {{ doc.text|replace('\n', '<br>')|safe if doc.text else "No content available" }}
             </div>
         </div>
 
@@ -64,7 +60,7 @@
         <div class="mb-4">
             <h5>Full Content:</h5>
             <div class="p-3 bg-light rounded">
-                {{ doc.full_text.0|replace('\n', '<br>')|safe }}
+                {{ doc.full_text|replace('\n', '<br>')|safe }}
             </div>
         </div>
         {% endif %}
@@ -74,7 +70,7 @@
         <div class="mb-4">
             <h5>Cleaned Content:</h5>
             <div class="p-3 bg-light rounded">
-                {{ doc.cleaned_text.0|replace('\n', '<br>')|safe }}
+                {{ doc.cleaned_text|replace('\n', '<br>')|safe }}
             </div>
         </div>
         {% endif %}
@@ -86,20 +82,20 @@
                     <tbody>
                         <tr>
                             <th>Author</th>
-                            <td>{{ doc.author.0 }}</td>
+                            <td>{{ doc.author }}</td>
                         </tr>
 
                         {% if doc.subreddit %}
                         <tr>
                             <th>Subreddit</th>
-                            <td>{{ doc.subreddit.0 }}</td>
+                            <td>{{ doc.subreddit }}</td>
                         </tr>
                         {% endif %}
 
                         {% if doc.source and doc.source != doc.subreddit %}
                         <tr>
                             <th>Source</th>
-                            <td>{{ doc.source.0 }}</td>
+                            <td>{{ doc.source }}</td>
                         </tr>
                         {% endif %}
 
@@ -113,43 +109,42 @@
                         {% if doc.created_at %}
                         <tr>
                             <th>Date</th>
-                            <td>{{ doc.created_at.0|replace('T', ' ')|replace('Z', '') }}</td>
+                            <td>{{ doc.created_at|replace('T', ' ')|replace('Z', '') }}</td>
                         </tr>
                         {% endif %}
 
                         {% if doc.score %}
                         <tr>
                             <th>Score</th>
-                            <td>{{ doc.score.0 }}</td>
+                            <td>{{ doc.score }}</td>
                         </tr>
                         {% endif %}
 
                         {% if doc.num_comments %}
                         <tr>
                             <th>Comments</th>
-                            <td>{{ doc.num_comments.0 }}</td>
+                            <td>{{ doc.num_comments }}</td>
                         </tr>
                         {% endif %}
 
                         {% if doc.is_duplicate is defined %}
                         <tr>
                             <th>Is Duplicate</th>
-                            <td>{{ doc.is_duplicate.0 }}</td>
+                            <td>{{ doc.is_duplicate }}</td>
                         </tr>
                         {% endif %}
 
                         {% if doc.subjectivity_score is defined and doc.subjectivity_score is not none and doc.subjectivity_score is number %}
                         <tr>
                             <th>Subjectivity</th>
-                            <td>{{ "%.2f"|format(doc.subjectivity_score.0) }}</td>
+                            <td>{{ "%.2f"|format(doc.subjectivity_score) }}</td>
                         </tr>
                         {% endif %}
 
                         {% if doc.parent_id %}
                         <tr>
                             <th>Parent ID</th>
-                            <!-- assuming starts with t3_ t1_ etc -->
-                            <td><a href="/document/{{ doc.parent_id.0[3:] }}">{{ doc.parent_id.0[3:]}}</a></td>
+                            <td>{{ doc.parent_id }}</td>
                         </tr>
                         {% endif %}
                     </tbody>

--- a/templates/document.html
+++ b/templates/document.html
@@ -17,20 +17,24 @@
     <div class="card-body">
         <div class="mb-4">
             {% if doc.platform %}
-            <span class="platform-tag platform-{{ doc.platform|lower|replace('+', '')|replace(' ', '') }}">
-                {{ doc.platform }}
+            <span class="platform-tag platform-{{ doc.platform|lower|replace('+', '')|replace(' ', '')|replace("['",'')|replace("']",'')|replace('["','')|replace('"]','') }}">
+                {{ doc.platform|join(', ') }}
             </span>
             {% endif %}
 
-            {% if doc.type %}
+            <!-- {% if doc.type %}
             <span class="badge bg-dark">
                 {{ doc.type }}
             </span>
-            {% endif %}
+            {% endif %} -->
 
             {% if doc.sentiment %}
-            <span class="badge {% if doc.sentiment == 'positive' %}bg-success{% elif doc.sentiment == 'negative' %}bg-danger{% else %}bg-secondary{% endif %}">
-                {{ doc.sentiment }}
+            <span class="badge 
+            {% if 'positive' in doc.sentiment %}bg-success
+            {% elif 'negative' in doc.sentiment %}bg-danger
+            {% else %}bg-secondary
+            {% endif %}">
+                {{ doc.sentiment|replace("['",'')|replace("']",'')|replace('["','')|replace('"]','') }}
             </span>
             {% endif %}
 
@@ -40,18 +44,18 @@
             </span>
             {% endif %}
 
-            {% if doc.word_count %}
+            <!-- {% if doc.word_count %}
             <span class="badge bg-secondary">
-                Words: {{ doc.word_count }}
+                Words: {{ doc.word_count[0] }}
             </span>
-            {% endif %}
+            {% endif %} -->
         </div>
 
         <!-- Original Text -->
         <div class="mb-4">
             <h5>Original Content:</h5>
             <div class="p-3 bg-light rounded">
-                {{ doc.text|replace('\n', '<br>')|safe if doc.text else "No content available" }}
+                {{ doc.text.0|replace('\n', '<br>')|safe if doc.text else "No content available" }}
             </div>
         </div>
 
@@ -60,7 +64,7 @@
         <div class="mb-4">
             <h5>Full Content:</h5>
             <div class="p-3 bg-light rounded">
-                {{ doc.full_text|replace('\n', '<br>')|safe }}
+                {{ doc.full_text.0|replace('\n', '<br>')|safe }}
             </div>
         </div>
         {% endif %}
@@ -70,7 +74,7 @@
         <div class="mb-4">
             <h5>Cleaned Content:</h5>
             <div class="p-3 bg-light rounded">
-                {{ doc.cleaned_text|replace('\n', '<br>')|safe }}
+                {{ doc.cleaned_text.0|replace('\n', '<br>')|safe }}
             </div>
         </div>
         {% endif %}
@@ -82,20 +86,20 @@
                     <tbody>
                         <tr>
                             <th>Author</th>
-                            <td>{{ doc.author }}</td>
+                            <td>{{ doc.author.0 }}</td>
                         </tr>
 
                         {% if doc.subreddit %}
                         <tr>
                             <th>Subreddit</th>
-                            <td>{{ doc.subreddit }}</td>
+                            <td>{{ doc.subreddit.0 }}</td>
                         </tr>
                         {% endif %}
 
                         {% if doc.source and doc.source != doc.subreddit %}
                         <tr>
                             <th>Source</th>
-                            <td>{{ doc.source }}</td>
+                            <td>{{ doc.source.0 }}</td>
                         </tr>
                         {% endif %}
 
@@ -109,42 +113,43 @@
                         {% if doc.created_at %}
                         <tr>
                             <th>Date</th>
-                            <td>{{ doc.created_at|replace('T', ' ')|replace('Z', '') }}</td>
+                            <td>{{ doc.created_at.0|replace('T', ' ')|replace('Z', '') }}</td>
                         </tr>
                         {% endif %}
 
                         {% if doc.score %}
                         <tr>
                             <th>Score</th>
-                            <td>{{ doc.score }}</td>
+                            <td>{{ doc.score.0 }}</td>
                         </tr>
                         {% endif %}
 
                         {% if doc.num_comments %}
                         <tr>
                             <th>Comments</th>
-                            <td>{{ doc.num_comments }}</td>
+                            <td>{{ doc.num_comments.0 }}</td>
                         </tr>
                         {% endif %}
 
                         {% if doc.is_duplicate is defined %}
                         <tr>
                             <th>Is Duplicate</th>
-                            <td>{{ doc.is_duplicate }}</td>
+                            <td>{{ doc.is_duplicate.0 }}</td>
                         </tr>
                         {% endif %}
 
                         {% if doc.subjectivity_score is defined and doc.subjectivity_score is not none and doc.subjectivity_score is number %}
                         <tr>
                             <th>Subjectivity</th>
-                            <td>{{ "%.2f"|format(doc.subjectivity_score) }}</td>
+                            <td>{{ "%.2f"|format(doc.subjectivity_score.0) }}</td>
                         </tr>
                         {% endif %}
 
                         {% if doc.parent_id %}
                         <tr>
                             <th>Parent ID</th>
-                            <td>{{ doc.parent_id }}</td>
+                            <!-- assuming starts with t3_ t1_ etc -->
+                            <td><a href="/document/{{ doc.parent_id.0[3:] }}">{{ doc.parent_id.0[3:]}}</a></td>
                         </tr>
                         {% endif %}
                     </tbody>

--- a/templates/search_results.html
+++ b/templates/search_results.html
@@ -1,7 +1,7 @@
 <!-- templates/search_results.html -->
 {% extends 'base.html' %}
-
 {% block title %}Search Results{% endblock %}
+
 
 {% block head %}
 {{ super() }}
@@ -227,49 +227,68 @@
                             <h5 class="mb-1">
                                 <a href="/document/{{ doc.id }}">
                                     {% if doc.title %}
-                                        {{ doc.title }}
-                                    {% elif doc.text and doc.text|length > 100 %}
-                                        {{ doc.text[:100] }}...
-                                    {% else %}
-                                        Document ID: {{ doc.id }}
+                                        {{ doc.title
+                                            | replace('+', '')
+                                            | replace("['", '')
+                                            | replace("']", '')
+                                            | replace('["', '')
+                                            | replace('"]', '') }}
+                                    {% elif doc.text is sequence and doc.text is not string %} 
+                                        {% if doc.text.0|length > 100 %}
+                                            {{doc.text.0[:100]}} ...
+                                            {% else %}
+                                            {{doc.text.0}}
+                                            {% endif %}
                                     {% endif %}
                                 </a>
                             </h5>
                             <div>
-                                {% if doc.platform %}
-                                <span class="platform-tag platform-{{ doc.platform|lower|replace('+', '')|replace(' ', '') }}">
-                                    {{ doc.platform }}
+                                {% if doc.platform %} 
+                                <span class="platform-tag platform-{{ doc.platform|lower|replace('+', '')|replace(' ', '')|replace("['",'')|replace("']",'')|replace('["','')|replace('"]','') }}">
+                                    {{ doc.platform|join(', ') }}
                                 </span>
                                 {% endif %}
 
-                                {% if doc.type %}
+                                <!-- {% if doc.type %}
                                 <span class="badge bg-dark">
-                                    {{ doc.type }}
+                                    {{ doc.type|join(', ') }}  
                                 </span>
-                                {% endif %}
+                                {% endif %} -->
+
                             </div>
                         </div>
 
-                        <p class="mb-1">
-                            {% if doc.text %}
-                                {% if doc.text|length > 300 %}
-                                    {{ doc.text[:300] }}...
+                        <p class="fw-light mb-1 fst-italic">
+                            {% if doc.text is sequence and doc.text is not string %}
+                                {% if doc.text[0]|length > 100 %}
+                                    {{ doc.text[0][:100] }} ...
+                                {% else %}
+                                    {{ doc.text[0] }}
+                                {% endif %}
+                            {% elif doc.text %}
+                                {% if doc.text|length > 100 %}
+                                    {{ doc.text[:100] }} ...
                                 {% else %}
                                     {{ doc.text }}
                                 {% endif %}
-                            {% endif %}
+                            {% endif %}                        
                         </p>
 
                         <div class="d-flex justify-content-between align-items-center mt-2">
                             <div>
                                 {% if doc.sentiment %}
-                                <span class="badge {% if doc.sentiment == 'positive' %}bg-success{% elif doc.sentiment == 'negative' %}bg-danger{% else %}bg-secondary{% endif %}">
-                                    {{ doc.sentiment }}
+                                <span class="badge 
+                                {% if 'positive' in doc.sentiment %}bg-success
+                                {% elif 'negative' in doc.sentiment %}bg-danger
+                                {% else %}bg-secondary
+                                {% endif %}">
+
+                                {{ doc.sentiment|replace("['",'')|replace("']",'')|replace('["','')|replace('"]','') }}
                                 </span>
                                 {% endif %}
 
                                 {% if doc.created_at %}
-                                <small class="text-muted ms-2">{{ doc.created_at|replace('T', ' ')|replace('Z', '') }}</small>
+                                <small class="text-muted ms-2">{{ doc.created_at|replace('T', ' ')|replace('Z', '')|replace("['",'')|replace("']",'') }}</small>
                                 {% endif %}
 
                                 {% if doc.score %}
@@ -277,14 +296,14 @@
                                 {% endif %}
 
                                 {% if doc.author %}
-                                <small class="text-muted ms-2">by: {{ doc.author }}</small>
+                                <small class="text-muted ms-2">by: {{ doc.author|join(', ') }}</small>
                                 {% endif %}
                             </div>
 
                             <div>
                                 {% if doc.content_quality or doc.pricing or doc.ui_ux or doc.technical or doc.customer_service %}
                                 <span class="badge bg-info" title="Has feature analysis">
-                                    <i class="bi bi-graph-up"></i> Analysis
+                                    <i class="bi bi-graph-up"></i> Analysis Available
                                 </span>
                                 {% endif %}
 

--- a/templates/search_results.html
+++ b/templates/search_results.html
@@ -1,7 +1,7 @@
 <!-- templates/search_results.html -->
 {% extends 'base.html' %}
-{% block title %}Search Results{% endblock %}
 
+{% block title %}Search Results{% endblock %}
 
 {% block head %}
 {{ super() }}
@@ -227,68 +227,49 @@
                             <h5 class="mb-1">
                                 <a href="/document/{{ doc.id }}">
                                     {% if doc.title %}
-                                        {{ doc.title
-                                            | replace('+', '')
-                                            | replace("['", '')
-                                            | replace("']", '')
-                                            | replace('["', '')
-                                            | replace('"]', '') }}
-                                    {% elif doc.text is sequence and doc.text is not string %} 
-                                        {% if doc.text.0|length > 100 %}
-                                            {{doc.text.0[:100]}} ...
-                                            {% else %}
-                                            {{doc.text.0}}
-                                            {% endif %}
+                                        {{ doc.title }}
+                                    {% elif doc.text and doc.text|length > 100 %}
+                                        {{ doc.text[:100] }}...
+                                    {% else %}
+                                        Document ID: {{ doc.id }}
                                     {% endif %}
                                 </a>
                             </h5>
                             <div>
-                                {% if doc.platform %} 
-                                <span class="platform-tag platform-{{ doc.platform|lower|replace('+', '')|replace(' ', '')|replace("['",'')|replace("']",'')|replace('["','')|replace('"]','') }}">
-                                    {{ doc.platform|join(', ') }}
+                                {% if doc.platform %}
+                                <span class="platform-tag platform-{{ doc.platform|lower|replace('+', '')|replace(' ', '') }}">
+                                    {{ doc.platform }}
                                 </span>
                                 {% endif %}
 
-                                <!-- {% if doc.type %}
+                                {% if doc.type %}
                                 <span class="badge bg-dark">
-                                    {{ doc.type|join(', ') }}  
+                                    {{ doc.type }}
                                 </span>
-                                {% endif %} -->
-
+                                {% endif %}
                             </div>
                         </div>
 
-                        <p class="fw-light mb-1 fst-italic">
-                            {% if doc.text is sequence and doc.text is not string %}
-                                {% if doc.text[0]|length > 100 %}
-                                    {{ doc.text[0][:100] }} ...
-                                {% else %}
-                                    {{ doc.text[0] }}
-                                {% endif %}
-                            {% elif doc.text %}
-                                {% if doc.text|length > 100 %}
-                                    {{ doc.text[:100] }} ...
+                        <p class="mb-1">
+                            {% if doc.text %}
+                                {% if doc.text|length > 300 %}
+                                    {{ doc.text[:300] }}...
                                 {% else %}
                                     {{ doc.text }}
                                 {% endif %}
-                            {% endif %}                        
+                            {% endif %}
                         </p>
 
                         <div class="d-flex justify-content-between align-items-center mt-2">
                             <div>
                                 {% if doc.sentiment %}
-                                <span class="badge 
-                                {% if 'positive' in doc.sentiment %}bg-success
-                                {% elif 'negative' in doc.sentiment %}bg-danger
-                                {% else %}bg-secondary
-                                {% endif %}">
-
-                                {{ doc.sentiment|replace("['",'')|replace("']",'')|replace('["','')|replace('"]','') }}
+                                <span class="badge {% if doc.sentiment == 'positive' %}bg-success{% elif doc.sentiment == 'negative' %}bg-danger{% else %}bg-secondary{% endif %}">
+                                    {{ doc.sentiment }}
                                 </span>
                                 {% endif %}
 
                                 {% if doc.created_at %}
-                                <small class="text-muted ms-2">{{ doc.created_at|replace('T', ' ')|replace('Z', '')|replace("['",'')|replace("']",'') }}</small>
+                                <small class="text-muted ms-2">{{ doc.created_at|replace('T', ' ')|replace('Z', '') }}</small>
                                 {% endif %}
 
                                 {% if doc.score %}
@@ -296,14 +277,14 @@
                                 {% endif %}
 
                                 {% if doc.author %}
-                                <small class="text-muted ms-2">by: {{ doc.author|join(', ') }}</small>
+                                <small class="text-muted ms-2">by: {{ doc.author }}</small>
                                 {% endif %}
                             </div>
 
                             <div>
                                 {% if doc.content_quality or doc.pricing or doc.ui_ux or doc.technical or doc.customer_service %}
                                 <span class="badge bg-info" title="Has feature analysis">
-                                    <i class="bi bi-graph-up"></i> Analysis Available
+                                    <i class="bi bi-graph-up"></i> Analysis
                                 </span>
                                 {% endif %}
 


### PR DESCRIPTION
fixed stylings for 

1. platform labels
2. sentiment labels
3. descriptions
4. titles
5. document page, same as above

added
1.  parent id is now a clickable link (to its document page if its accessible, assumed the parent id always starts with t3_ t1_ etc. lmk if its not)